### PR TITLE
코멘트 작성 시 계산기 비활성화

### DIFF
--- a/js/calculator.js
+++ b/js/calculator.js
@@ -50,6 +50,9 @@ document.onkeydown = function(e) {
     if(event.target.tagName === "BUTTON"){
         return
     }
+    if(event.target.tagName === "TEXTAREA"){
+        return
+    }
 
     // backspace shortcut key
     if (e.which == 8 | e.which == 46) {


### PR DESCRIPTION
tag이름이 textarea인 경우 계산기 shotkey 작동되지 않게 함
close: #189 